### PR TITLE
Update 7_get_started_with_real_robot.md

### DIFF
--- a/examples/7_get_started_with_real_robot.md
+++ b/examples/7_get_started_with_real_robot.md
@@ -111,6 +111,11 @@ sudo chmod 666 /dev/ttyACM0
 sudo chmod 666 /dev/ttyACM1
 ```
 
+or you can add the user to the `dialout` group:
+```bash
+sudo usermod -a -G dialout $USER
+```
+
 *Listing and Configuring Motors*
 
 Next, you'll need to list the motors for each arm, including their name, index, and model. Initially, each motor is assigned the factory default index `1`. Since each motor requires a unique index to function correctly when connected in a chain on a common bus, you'll need to assign different indices. It's recommended to use an ascending index order, starting from `1` (e.g., `1, 2, 3, 4, 5, 6`). These indices will be saved in the persistent memory of each motor during the first connection.


### PR DESCRIPTION
Added a generic linux command to access USB devices without the need for sudo (this is a common trick for embedded devices on linux)

